### PR TITLE
Fix missing category group persistence

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -38,7 +38,8 @@ export const CONFIG = {
     API_KEY: 'budgetTracker_apiKey',
     SHEET_ID: 'budgetTracker_sheetId',
     MERCHANT_GROUPS: 'budgetTracker_merchantGroups',
-    CATEGORIES: 'budgetTracker_categories'
+    CATEGORIES: 'budgetTracker_categories',
+    CATEGORY_GROUPS: 'budgetTracker_categoryGroups'
   },
 
   // Merchant Patterns for Auto-Categorization

--- a/js/modules/categories.js
+++ b/js/modules/categories.js
@@ -8,7 +8,7 @@ export class CategoryManager {
   constructor(sheetsAPI) {
     this.sheetsAPI = sheetsAPI;
     this.categories = Storage.getCategories();
-    this.categoryGroups = CONFIG.CATEGORY_GROUPS;
+    this.categoryGroups = Storage.getCategoryGroups();
     this.merchantGroups = Storage.getMerchantGroups();
   }
 

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -67,6 +67,14 @@ export class Storage {
     this.set(CONFIG.STORAGE_KEYS.MERCHANT_GROUPS, groups);
   }
 
+  static getCategoryGroups() {
+    return this.get(CONFIG.STORAGE_KEYS.CATEGORY_GROUPS, CONFIG.CATEGORY_GROUPS);
+  }
+
+  static saveCategoryGroups(groups) {
+    this.set(CONFIG.STORAGE_KEYS.CATEGORY_GROUPS, groups);
+  }
+
   static getCategories() {
     return this.get(CONFIG.STORAGE_KEYS.CATEGORIES, CONFIG.CATEGORIES);
   }


### PR DESCRIPTION
## Summary
- add a storage key for category groups
- persist category group settings in Storage
- load category groups from Storage when initializing the CategoryManager

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1be471b8832ea7afa7b6ab59a346