### PR TITLE
Add persistent category group management

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -38,7 +38,8 @@ export const CONFIG = {
     API_KEY: 'budgetTracker_apiKey',
     SHEET_ID: 'budgetTracker_sheetId',
     MERCHANT_GROUPS: 'budgetTracker_merchantGroups',
-    CATEGORIES: 'budgetTracker_categories'
+    CATEGORIES: 'budgetTracker_categories',
+    CATEGORY_GROUPS: 'budgetTracker_categoryGroups'
   },
 
   // Merchant Patterns for Auto-Categorization

--- a/js/modules/categories.js
+++ b/js/modules/categories.js
@@ -8,7 +8,7 @@ export class CategoryManager {
   constructor(sheetsAPI) {
     this.sheetsAPI = sheetsAPI;
     this.categories = Storage.getCategories();
-    this.categoryGroups = CONFIG.CATEGORY_GROUPS;
+    this.categoryGroups = Storage.getCategoryGroups();
     this.merchantGroups = Storage.getMerchantGroups();
   }
 

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -74,4 +74,12 @@ export class Storage {
   static saveCategories(categories) {
     this.set(CONFIG.STORAGE_KEYS.CATEGORIES, categories);
   }
+
+  static getCategoryGroups() {
+    return this.get(CONFIG.STORAGE_KEYS.CATEGORY_GROUPS, CONFIG.CATEGORY_GROUPS);
+  }
+
+  static saveCategoryGroups(groups) {
+    this.set(CONFIG.STORAGE_KEYS.CATEGORY_GROUPS, groups);
+  }
 }


### PR DESCRIPTION
## Summary
- add CATEGORY_GROUPS storage key
- implement `getCategoryGroups` and `saveCategoryGroups`
- load stored category groups in `CategoryManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf2bfd120832ea6869c01677612b8