### PR TITLE
Add basic test setup

### DIFF
--- a/js/utils/formatters.js
+++ b/js/utils/formatters.js
@@ -4,11 +4,11 @@ export class Formatters {
   static currency(amount, options = {}) {
     const defaults = {
       style: 'currency',
-      currency: 'USD',
+      currency: 'CAD',
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
     };
-    
+
     return new Intl.NumberFormat('en-US', { ...defaults, ...options }).format(amount);
   }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "lint": "echo 'No linting configured - vanilla JS project'",
-    "test": "echo 'No tests configured - manual testing required'"
+    "test": "node --test"
   },
   "keywords": [
     "budget",

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Formatters } from '../js/utils/formatters.js';
+
+test('Formatters.currency formats numbers as CAD currency', () => {
+  assert.strictEqual(Formatters.currency(1234.5), 'CA$1,234.50');
+});


### PR DESCRIPTION
## Summary
- configure the `test` script to use Node's built‑in test runner
- add a sample test for `Formatters.currency`
- switch default currency to CAD

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bf2cb9550832ea4bfb90178445c87